### PR TITLE
Pinning connexion to <3.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - setuptools
   run:
     - python >=3.8
-    - connexion >=2.7 <3.0
+    - connexion >=2.7,<3.0
     - email-validator
     - fasteners
     - flask >2.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "seamm-dashboard" %}
-{% set version = "2024.1.1" %}
-{% set sha256 = "7b204c09274d8e13b49df5276e4b354e5742bef8773e0bcaeaa6c7580ffa7f26" %}
+{% set version = "2024.3.27" %}
+{% set sha256 = "85a132e0ea781421699a67522453e69ab64b7bce46e70dab624104d17d1aa1e9" %}
 
 package:
   name: {{ name|lower }}
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 1
+  number: 0
   noarch: python
   entry_points:
     - seamm_dashboard=seamm_dashboard.results_dashboard:run
@@ -24,11 +24,11 @@ requirements:
     - python >=3.11
     - setuptools
   run:
-    - python >=3.11
+    - python >=3.8
     - connexion >=2.7,<3.0
     - email-validator
     - fasteners
-    - flask >2.0
+    - flask >2.0,<3.0
     - flask-authorize
     - flask-bootstrap
     - flask-cors

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -21,10 +21,10 @@ build:
 requirements:
   host:
     - pip
-    - python >=3.8
+    - python >=3.11
     - setuptools
   run:
-    - python >=3.8
+    - python >=3.11
     - connexion >=2.7,<3.0
     - email-validator
     - fasteners

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - seamm_dashboard=seamm_dashboard.results_dashboard:run
@@ -25,7 +25,7 @@ requirements:
     - setuptools
   run:
     - python >=3.8
-    - connexion >=2.7
+    - connexion >=2.7 <3.0
     - email-validator
     - fasteners
     - flask >2.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
The Dashboard does not work with connexion 3.x, so pinned to <3.0. Flask also.
<!--
Please add any other relevant info below:
-->
